### PR TITLE
Actualizar librerías de google y de dependencias/librerías #19

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,4 @@
+//noinspection GradleDependency
 apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
 
@@ -8,14 +9,15 @@ repositories {
 }
 
 android {
-    compileSdkVersion 26
-    //buildToolsVersion '26.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
     defaultConfig {
         applicationId "io.github.jokoframework"
         minSdkVersion 19
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
+        ndk.abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
 
@@ -43,6 +45,7 @@ android {
     dataBinding{
         enabled = true
     }
+
 }
 
 dependencies {
@@ -58,36 +61,38 @@ dependencies {
         transitive = true
     }
     implementation 'com.parse:parse-android:1.15.8'
-    implementation 'com.google.code.gson:gson:2.7'
-    implementation 'com.android.support:multidex:1.0.2'
+    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.android.support:multidex:1.0.3'
     implementation 'com.androidplot:androidplot-core:0.6.1'
     implementation 'org.apache.commons:commons-lang3:3.4'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.2'
     //noinspection GradleCompatible
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support:support-vector-drawable:26.+'
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    //noinspection GradleCompatible
+    implementation 'com.android.support:support-vector-drawable:28.0.0'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.google.firebase:firebase-messaging:11.0.2'
     implementation 'com.squareup.retrofit2:retrofit:2.1.0'
-    implementation 'com.facebook.android:facebook-login:[4,5)'
+    implementation 'com.facebook.android:facebook-login:4.42.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.1.0'
     implementation 'com.squareup.retrofit2:adapter-rxjava:2.1.0'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.5.3'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.5.3'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.5.3'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.9.6'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.9.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
     implementation 'com.jakewharton.rxbinding:rxbinding-design:0.4.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.4.1'
-    implementation 'com.squareup.okhttp3:okhttp:3.4.1'
+    implementation 'com.squareup.okhttp3:okhttp:3.10.0'
     implementation 'com.google.android.gms:play-services-gcm:11.0.2'
     implementation 'com.google.android.gms:play-services-analytics:11.0.2'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
-    implementation 'com.android.volley:volley:1.0.0'
+    implementation 'com.android.volley:volley:1.1.0'
     implementation 'android.arch.persistence.room:runtime:1.0.0'
-    implementation 'com.android.support:design:26.1.0'
+    //noinspection GradleCompatible
+    implementation 'com.android.support:design:28.0.0'
     implementation project(':mboehaolib')
 
     implementation 'com.google.zxing:core:3.3.0'
-    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.squareup.picasso:picasso:2.5.2'
     implementation 'io.fotoapparat.fotoapparat:library:1.4.1'
     testCompile 'org.mockito:mockito-core:1.10.19'
@@ -95,6 +100,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     annotationProcessor "android.arch.persistence.room:compiler:1.0.0"
+    compile 'com.android.support:support-annotations:28.0.0'
 
 
 }

--- a/mboehalib/build.gradle
+++ b/mboehalib/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -26,6 +26,6 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:26.+'
+    compile 'com.android.support:appcompat-v7:26.1.0'
     testCompile 'junit:junit:4.12'
 }

--- a/mboehaolib/build.gradle
+++ b/mboehaolib/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation 'com.parse:parse-android:1.15.8'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.2'
     //noinspection GradleCompatible
-    implementation 'com.android.support:appcompat-v7:26.+'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.jakewharton.rxbinding:rxbinding-design:0.4.0'
     implementation 'com.squareup.retrofit2:retrofit:2.1.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.1.0'


### PR DESCRIPTION
1- Modernización de la aplicación; actualizando todas las librerias que tengan una actualización disponible.
2- Se cambió el targetSDK al targetSDk 28 para cumplir con el requerimiento del playstore.